### PR TITLE
Boolean handling

### DIFF
--- a/src/main/clojure/clojure/java/data.clj
+++ b/src/main/clojure/clojure/java/data.clj
@@ -32,7 +32,8 @@
 
 (defn- make-getter-fn [method]
   (fn [instance]
-    (from-java (.invoke method instance nil))))
+    (clojure.lang.Reflector/prepRet (.getReturnType method) 
+                                    (from-java (.invoke method instance nil)))))
 
 (defn- add-getter-fn [the-map prop-descriptor]
   (let [name (.getName prop-descriptor)

--- a/src/test/clojure/clojure/java/test_data.clj
+++ b/src/test/clojure/clojure/java/test_data.clj
@@ -10,7 +10,7 @@
   (:use clojure.java.data)
   (:use [clojure.tools.logging :only (log* info)])
   (:use clojure.test)
-  (:import (clojure.java.data.test Person Address State Primitive)))
+  (:import (clojure.java.data.test Person Address State Primitive BooleanTest)))
 
 (deftest clojure-to-java
   (let [person (to-java Person {:name "Bob" 
@@ -103,3 +103,10 @@
                :stringArray ["Argument" "Vector"]}]
     (is (= datum
            (from-java (to-java Primitive datum))))))
+
+(deftest booleans-from-java
+  (let [java-datum (new BooleanTest)]
+    (is (= :false (if (:boolMember (from-java java-datum))
+                        :true
+                        :false)))))
+

--- a/src/test/java/clojure/java/data/test/BooleanTest.java
+++ b/src/test/java/clojure/java/data/test/BooleanTest.java
@@ -1,0 +1,18 @@
+package clojure.java.data.test;
+
+public class BooleanTest {
+
+  private boolean boolMember = false;
+
+  public BooleanTest() {}
+
+  public boolean isBoolMember() {
+    return this.boolMember;
+  }
+
+  public void setBoolMember(boolean boolMember) {
+    this.boolMember = boolMember;
+  }
+
+}
+


### PR DESCRIPTION
The problem are boolean attributes because they are converted into Booleans when Reflection is used to call the getter but not to Boolean.TRUE and Boolean.FALSE. Therefore, the return value needs to be converted using clojure.lang.Reflector/prepRet.
